### PR TITLE
Change undefined deps to null, so they can be output.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -22,6 +22,10 @@ process.stdin.pipe(concat(function (body) {
     console.log('[');
     rows.forEach(function (row, index) {
         if (index > 0) console.log(',');
+        Object.keys(row.deps).forEach(function (key) {
+            if (typeof row.deps[key] === 'undefined')
+                row.deps[key] = null;
+        });
         console.log(JSON.stringify(row));
     });
     console.log(']');


### PR DESCRIPTION
I wanted to see what external dependencies were unresolved in a bundle produced with the `--no-bundle-external` option.  Since `JSON.stringify()` omits `undefined` values, unresolved dependencies were missing from the output.

It wasn't immediately obvious to me if `module-deps` has another way of representing this, but I can adjust this if needed.