### PR TITLE
update emca version

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (src) {
 
     var ast = parse(src, {
       range: true,
-      ecmaVersion: 6
+      ecmaVersion: 8
     });
 
     ast.body = ast.body.filter(function(node) {


### PR DESCRIPTION
this will add support for ECMAScript 8 features, including `async` and all versions of splat syntax. acorn 4.0.0+ already supports up to 8, so this option is already included with the current dependencies in `packages.json`.